### PR TITLE
Add resolution support in DateFieldDefinitionBuilder

### DIFF
--- a/magnolia-builders/src/main/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilder.java
+++ b/magnolia-builders/src/main/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilder.java
@@ -1,10 +1,13 @@
 package com.merkle.oss.magnolia.definition.builder.simple;
 
 import info.magnolia.ui.field.DateFieldDefinition;
-import info.magnolia.ui.field.TextFieldDefinition;
+
+import java.util.Optional;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
+
+import com.vaadin.shared.ui.datefield.DateResolution;
+import com.vaadin.shared.ui.datefield.DateTimeResolution;
 
 /**
  * builds a {@link DateFieldDefinition}
@@ -53,9 +56,17 @@ public class DateFieldDefinitionBuilder extends AbstractConfiguredFieldDefinitio
 		return self();
 	}
 
-	public DateFieldDefinitionBuilder resolution(final String resolution) {
+	private DateFieldDefinitionBuilder resolution(final String resolution) {
 		this.resolution = resolution;
 		return self();
+	}
+
+	public DateFieldDefinitionBuilder resolution(final DateTimeResolution resolution) {
+		return resolution(resolution.name());
+	}
+
+	public DateFieldDefinitionBuilder resolution(final DateResolution resolution) {
+		return resolution(resolution.name());
 	}
 
 	public DateFieldDefinition build(final String name) {

--- a/magnolia-builders/src/main/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilder.java
+++ b/magnolia-builders/src/main/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilder.java
@@ -20,6 +20,8 @@ public class DateFieldDefinitionBuilder extends AbstractConfiguredFieldDefinitio
 	private String dateFormat;
 	@Nullable
 	private String timeFormat;
+	@Nullable
+	private String resolution;
 
 	public DateFieldDefinitionBuilder() {}
 	public DateFieldDefinitionBuilder(final DateFieldDefinition definition) {
@@ -28,6 +30,7 @@ public class DateFieldDefinitionBuilder extends AbstractConfiguredFieldDefinitio
 		inISO8061Format(definition.isInISO8061Format());
 		dateFormat(definition.getDateFormat());
 		timeFormat(definition.getTimeFormat());
+		resolution(definition.getResolution());
 	}
 
 	public DateFieldDefinitionBuilder time(final boolean time) {
@@ -50,6 +53,11 @@ public class DateFieldDefinitionBuilder extends AbstractConfiguredFieldDefinitio
 		return self();
 	}
 
+	public DateFieldDefinitionBuilder resolution(final String resolution) {
+		this.resolution = resolution;
+		return self();
+	}
+
 	public DateFieldDefinition build(final String name) {
 		final DateFieldDefinition definition = new DateFieldDefinition();
 		super.populate(definition, name);
@@ -57,6 +65,7 @@ public class DateFieldDefinitionBuilder extends AbstractConfiguredFieldDefinitio
 		Optional.ofNullable(inISO8061Format).ifPresent(definition::setInISO8061Format);
 		Optional.ofNullable(dateFormat).ifPresent(definition::setDateFormat);
 		Optional.ofNullable(timeFormat).ifPresent(definition::setTimeFormat);
+		Optional.ofNullable(resolution).ifPresent(definition::setResolution);
 		return definition;
 	}
 }

--- a/magnolia-builders/src/test/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilderTest.java
+++ b/magnolia-builders/src/test/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilderTest.java
@@ -1,6 +1,8 @@
 package com.merkle.oss.magnolia.definition.builder.simple;
 
 import com.merkle.oss.magnolia.definition.builder.AbstractFieldDefinitionBuilderTestCase;
+import com.vaadin.shared.ui.datefield.DateTimeResolution;
+
 import info.magnolia.ui.field.DateFieldDefinition;
 import org.junit.jupiter.api.Test;
 
@@ -16,11 +18,11 @@ class DateFieldDefinitionBuilderTest extends AbstractFieldDefinitionBuilderTestC
 				.timeFormat("timeFormat")
 				.time(true)
 				.inISO8061Format(true)
-				.resolution("minute")
+				.resolution(DateTimeResolution.MINUTE)
 				.build("date");
 		assertEquals("dateFormat", definition.getDateFormat());
 		assertEquals("timeFormat", definition.getTimeFormat());
-		assertEquals("minute", definition.getResolution());
+		assertEquals("MINUTE", definition.getResolution());
 		assertTrue(definition.isTime());
 		assertTrue(definition.isInISO8061Format());
 

--- a/magnolia-builders/src/test/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilderTest.java
+++ b/magnolia-builders/src/test/java/com/merkle/oss/magnolia/definition/builder/simple/DateFieldDefinitionBuilderTest.java
@@ -16,9 +16,11 @@ class DateFieldDefinitionBuilderTest extends AbstractFieldDefinitionBuilderTestC
 				.timeFormat("timeFormat")
 				.time(true)
 				.inISO8061Format(true)
+				.resolution("minute")
 				.build("date");
 		assertEquals("dateFormat", definition.getDateFormat());
 		assertEquals("timeFormat", definition.getTimeFormat());
+		assertEquals("minute", definition.getResolution());
 		assertTrue(definition.isTime());
 		assertTrue(definition.isInISO8061Format());
 
@@ -26,6 +28,7 @@ class DateFieldDefinitionBuilderTest extends AbstractFieldDefinitionBuilderTestC
 		assertEquals(Date.class, emptyDefinition.getType());
 		assertEquals("yyyy-MM-dd", emptyDefinition.getDateFormat());
 		assertEquals("HH:mm", emptyDefinition.getTimeFormat());
+		assertNull(emptyDefinition.getResolution());
 		assertFalse(emptyDefinition.isTime());
 		assertFalse(emptyDefinition.isInISO8061Format());
 	}


### PR DESCRIPTION
Add resolution support in DateFieldDefinitionBuilder (introduced in Magnolia 6.2.44)